### PR TITLE
Changed the required version of intellij idea

### DIFF
--- a/Gruvbox.icls
+++ b/Gruvbox.icls
@@ -1,4 +1,4 @@
-<scheme name="Gruvbox" version="142" parent_scheme="Default">
+<scheme name="Gruvbox" version="141" parent_scheme="Default">
   <option name="LINE_SPACING" value="1.0" />
   <font>
     <option name="EDITOR_FONT_NAME" value="Hack" />


### PR DESCRIPTION
The current required version build of Intellij Idea is the 142th, which makes impossible to use the color scheme with the current version of Android Studio. I've changed it to the 141th version and it seems to work fine. 
