### PR TITLE
Change annotations from gray to orange

### DIFF
--- a/Gruvbox.icls
+++ b/Gruvbox.icls
@@ -63,7 +63,7 @@
     <option name="ABSTRACT_METHOD_ATTRIBUTES" baseAttributes="METHOD_CALL_ATTRIBUTES" />
     <option name="ANNOTATION_NAME_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="83786e" />
+        <option name="FOREGROUND" value="fe8019" />
       </value>
     </option>
     <option name="ANONYMOUS_CLASS_NAME_ATTRIBUTES">
@@ -673,7 +673,7 @@
     <option name="JS.REGEXP" baseAttributes="DEFAULT_STRING" />
     <option name="KOTLIN_ANNOTATION">
       <value>
-        <option name="FOREGROUND" value="83786e" />
+        <option name="FOREGROUND" value="fe8019" />
       </value>
     </option>
     <option name="KOTLIN_LABEL">


### PR DESCRIPTION
Since Java/Android development can be full of annotations, I thought switching from gray to orange made things a little more exciting. Thoughts?

### Before

<img width="656" alt="annotations-gray" src="https://cloud.githubusercontent.com/assets/2344137/14610519/453c9a90-055c-11e6-89da-94a8ce24b32e.png">

### After

<img width="651" alt="annotations-orange" src="https://cloud.githubusercontent.com/assets/2344137/14610762/27e6ceba-055d-11e6-8a04-ba5441ca81c2.png">

This uses the bright orange from the dark Gruvbox color palette (bottom-right-most color):

![](https://camo.githubusercontent.com/cdb2f2e986c564b515c0c698e6c45b4ab5d725a9/687474703a2f2f692e696d6775722e636f6d2f776136363678672e706e67)
