### PR TITLE
add IntelliJ IDEA Community Edition to the installation script

### DIFF
--- a/install-osx.bash
+++ b/install-osx.bash
@@ -5,7 +5,7 @@ if [ ! -d ~/Library ]; then
   exit 1
 fi
 
-for i in ~/Library/Preferences/{DataGrip,IntelliJ,RubyMine,PhpStorm,WebStorm,AndroidStudio,PyCharm}*; do
+for i in ~/Library/Preferences/{DataGrip,IntelliJ,IdeaIC,RubyMine,PhpStorm,WebStorm,AndroidStudio,PyCharm}*; do
   mkdir -p "${i}/Colors"
   echo "Installing in Colors directory: ${i}/Colors"
   cp Gruvbox.icls "${i}/Colors"


### PR DESCRIPTION
The IntelliJ IDEA CE's preferences dir in my system is at `~/Library/Preferences/IdeaIC2016.1/`. So I add that to the script.
