### PR TITLE
Update install config directory to work with latest IntelliJ install

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
 if [ "$(uname)" == "Darwin" ]; then
-  config_dirs_template="$HOME/Library/Preferences/XXX*"
+  config_dirs_template="$HOME/Library/Application Support/JetBrains/XXX*"
 else
   config_dirs_template="$HOME/.XXX*/config"
 fi
 
 shopt -s nullglob # to prevent the config_dir glob misbehaving below
+
+PREV_IFS=$IFS # save original IFS
+IFS=$(echo -en "\n\b") # set IFS to properly handle directories with space in name
 
 for product in CLion DataGrip IntelliJ IdeaIC RubyMine PhpStorm WebStorm AndroidStudio PyCharm GoLand Rider AppCode; do
   config_dirs="${config_dirs_template//XXX/$product}"
@@ -17,3 +20,5 @@ for product in CLion DataGrip IntelliJ IdeaIC RubyMine PhpStorm WebStorm Android
     cp *.icls "$colors_dir"
   done
 done
+
+IFS=$PREV_IFS # restore original $IFS


### PR DESCRIPTION
Hi @Caleb, I noticed the install script does not work with the latest IntelliJ install on OSX.

I did some digging and found that the config directory is different than the one used in the script.

I have updated the script but only tested and verified the changes with IntelliJ since I do not have the other products supported. 

Would be good to verify if the updated config directory is valid for other products before merging. 